### PR TITLE
feat: `all(…ctx)` reject with Error (not Array)

### DIFF
--- a/src/promise.js
+++ b/src/promise.js
@@ -2,6 +2,17 @@
 
 const once = require('lodash.once');
 
+class MultipleError extends Error {
+
+  constructor(errors = []) {
+    const msg = errors.map(e => e.stack).join('/n/n');
+
+    super(msg);
+
+    this.errors = errors;
+  }
+}
+
 /**
  * Create a promise like object.
  *
@@ -76,7 +87,7 @@ exports.run = function(...thenables) {
  *   );
  *
  * @param  {...Promise<void,Error>} thenables Thenables returned by Context#ok or Context#shouldFail
- * @return {Promise<void,Array<Error>>}
+ * @return {Promise<void,Error>}
  */
 exports.all = function(...thenables) {
   return [].concat(...thenables).reduce(
@@ -90,6 +101,6 @@ exports.all = function(...thenables) {
       return;
     }
 
-    return Promise.reject(failures);
+    return Promise.reject(new MultipleError(failures));
   });
 };

--- a/tests/promise.js
+++ b/tests/promise.js
@@ -215,11 +215,9 @@ describe('promise', function() {
         q.thenable(ok)
       ).then(
         () => Promise.reject(new Error('unexpected')),
-        es => {
+        () => {
           expect(ok).to.have.callCount(2);
           expect(fail).to.have.callCount(2);
-          expect(es[0]).to.equal(err1);
-          expect(es[1]).to.equal(err2);
         }
       );
     });


### PR DESCRIPTION
Logging of an array of error is not easy to read. Instead, we create an error and build its message by joining each error message.

Breaking Change: Change promise helper running all tests in sequences to return a proper error instead of an array of error.